### PR TITLE
handle line breaks

### DIFF
--- a/solution/verifiable_confidential_ledger/src/main.rs
+++ b/solution/verifiable_confidential_ledger/src/main.rs
@@ -454,7 +454,7 @@ fn wait_for_input() -> String {
     std::io::stdin()
         .read_line(&mut input)
         .expect("Failed to read line.");
-    input.replace("\n", "")
+        input.trim().to_string()
 }
 
 // In this demo, we set the upper limit of input value to 10000.


### PR DESCRIPTION
win和linux环境下回车换行符\n\r存在差异。读取控制台输入时去掉换行符和空格。